### PR TITLE
feat: selectively use corepack with yarn

### DIFF
--- a/lib/modules/manager/npm/extract/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/manager/npm/extract/__snapshots__/index.spec.ts.snap
@@ -15,6 +15,7 @@ Object {
   "lernaPackages": undefined,
   "managerData": Object {
     "lernaJsonFile": undefined,
+    "packageManager": false,
     "yarnZeroInstall": false,
   },
   "npmLock": undefined,
@@ -137,6 +138,7 @@ Object {
   "lernaPackages": undefined,
   "managerData": Object {
     "lernaJsonFile": undefined,
+    "packageManager": false,
     "yarnZeroInstall": false,
   },
   "npmLock": undefined,
@@ -313,6 +315,7 @@ Object {
   "lernaPackages": undefined,
   "managerData": Object {
     "lernaJsonFile": undefined,
+    "packageManager": false,
     "yarnZeroInstall": false,
   },
   "npmLock": undefined,
@@ -362,6 +365,7 @@ Object {
   "lernaPackages": undefined,
   "managerData": Object {
     "lernaJsonFile": undefined,
+    "packageManager": false,
     "yarnZeroInstall": false,
   },
   "npmLock": "package-lock.json",
@@ -396,6 +400,7 @@ Object {
   "lernaPackages": undefined,
   "managerData": Object {
     "lernaJsonFile": undefined,
+    "packageManager": true,
     "yarnZeroInstall": false,
   },
   "npmLock": undefined,
@@ -463,6 +468,7 @@ Object {
   "lernaPackages": undefined,
   "managerData": Object {
     "lernaJsonFile": undefined,
+    "packageManager": false,
     "yarnZeroInstall": false,
   },
   "npmLock": undefined,
@@ -517,6 +523,7 @@ Object {
   "lernaPackages": undefined,
   "managerData": Object {
     "lernaJsonFile": undefined,
+    "packageManager": false,
     "yarnZeroInstall": false,
   },
   "npmLock": undefined,
@@ -653,6 +660,7 @@ Object {
   "lernaPackages": undefined,
   "managerData": Object {
     "lernaJsonFile": "lerna.json",
+    "packageManager": false,
     "yarnZeroInstall": false,
   },
   "npmLock": undefined,
@@ -789,6 +797,7 @@ Object {
   "lernaPackages": undefined,
   "managerData": Object {
     "lernaJsonFile": "lerna.json",
+    "packageManager": false,
     "yarnZeroInstall": false,
   },
   "npmLock": undefined,
@@ -925,6 +934,7 @@ Object {
   "lernaPackages": undefined,
   "managerData": Object {
     "lernaJsonFile": undefined,
+    "packageManager": false,
     "yarnZeroInstall": false,
   },
   "npmLock": undefined,
@@ -947,6 +957,7 @@ Object {
   "lernaPackages": undefined,
   "managerData": Object {
     "lernaJsonFile": "lerna.json",
+    "packageManager": false,
     "yarnZeroInstall": false,
   },
   "npmLock": undefined,
@@ -1085,6 +1096,7 @@ Object {
   "lernaPackages": undefined,
   "managerData": Object {
     "lernaJsonFile": "lerna.json",
+    "packageManager": false,
     "yarnZeroInstall": false,
   },
   "npmLock": undefined,
@@ -1107,6 +1119,7 @@ Object {
   "lernaPackages": undefined,
   "managerData": Object {
     "lernaJsonFile": "lerna.json",
+    "packageManager": false,
     "yarnZeroInstall": false,
   },
   "npmLock": undefined,
@@ -1131,6 +1144,7 @@ Object {
   "lernaPackages": undefined,
   "managerData": Object {
     "lernaJsonFile": undefined,
+    "packageManager": false,
     "yarnZeroInstall": false,
   },
   "npmLock": undefined,
@@ -1269,6 +1283,7 @@ Object {
   "lernaPackages": undefined,
   "managerData": Object {
     "lernaJsonFile": undefined,
+    "packageManager": false,
     "yarnZeroInstall": false,
   },
   "npmLock": undefined,
@@ -1387,6 +1402,7 @@ Object {
   "lernaPackages": undefined,
   "managerData": Object {
     "lernaJsonFile": undefined,
+    "packageManager": false,
     "yarnZeroInstall": false,
   },
   "npmLock": undefined,
@@ -1523,6 +1539,7 @@ Object {
   "lernaPackages": undefined,
   "managerData": Object {
     "lernaJsonFile": undefined,
+    "packageManager": false,
     "yarnZeroInstall": true,
   },
   "npmLock": undefined,
@@ -1533,6 +1550,41 @@ Object {
   "pnpmShrinkwrap": undefined,
   "skipInstalls": false,
   "yarnLock": "yarn.lock",
+  "yarnWorkspacesPackages": undefined,
+}
+`;
+
+exports[`modules/manager/npm/extract/index detects a packageManager 1`] = `
+Object {
+  "constraints": Object {
+    "yarn": "3.0.0",
+  },
+  "deps": Array [
+    Object {
+      "commitMessageTopic": "Yarn",
+      "currentValue": "3.0.0",
+      "datasource": "npm",
+      "depName": "yarn",
+      "depType": "packageManager",
+      "packageName": "@yarnpkg/cli",
+      "prettyDepType": "packageManager",
+    },
+  ],
+  "lernaClient": undefined,
+  "lernaPackages": undefined,
+  "managerData": Object {
+    "lernaJsonFile": undefined,
+    "packageManager": true,
+    "yarnZeroInstall": false,
+  },
+  "npmLock": undefined,
+  "npmrc": undefined,
+  "packageFileVersion": undefined,
+  "packageJsonName": undefined,
+  "packageJsonType": "app",
+  "pnpmShrinkwrap": undefined,
+  "skipInstalls": true,
+  "yarnLock": undefined,
   "yarnWorkspacesPackages": undefined,
 }
 `;

--- a/lib/modules/manager/npm/extract/index.spec.ts
+++ b/lib/modules/manager/npm/extract/index.spec.ts
@@ -671,6 +671,17 @@ describe('modules/manager/npm/extract/index', () => {
     });
   });
 
+  it('detects a packageManager', async () => {
+    const res = await npmExtract.extractPackageFile(
+      JSON.stringify({ packageManager: 'yarn@3.0.0' }),
+      'package.json',
+      defaultConfig
+    );
+    expect(res).toMatchSnapshot({
+      managerData: { packageManager: true },
+    });
+  });
+
   describe('.postExtract()', () => {
     it('runs', async () => {
       await expect(npmExtract.postExtract([], false)).resolves.not.toThrow();

--- a/lib/modules/manager/npm/extract/index.ts
+++ b/lib/modules/manager/npm/extract/index.ts
@@ -332,6 +332,7 @@ export async function extractPackageFile(
     return dep;
   }
 
+  let packageManager = false;
   for (const depType of Object.keys(depTypes)) {
     let dependencies = packageJson[depType];
     if (dependencies) {
@@ -343,6 +344,7 @@ export async function extractPackageFile(
             break;
           }
           dependencies = { [match.groups.name]: match.groups.range };
+          packageManager = true;
         }
         for (const [key, val] of Object.entries(
           dependencies as NpmPackageDependency
@@ -409,6 +411,7 @@ export async function extractPackageFile(
     managerData: {
       lernaJsonFile,
       yarnZeroInstall,
+      packageManager,
     },
     lernaClient,
     lernaPackages,

--- a/lib/modules/manager/npm/post-update/__snapshots__/yarn.spec.ts.snap
+++ b/lib/modules/manager/npm/post-update/__snapshots__/yarn.spec.ts.snap
@@ -800,3 +800,27 @@ Array [
   },
 ]
 `;
+
+exports[`modules/manager/npm/post-update/yarn uses corepack if packageManager is set 1`] = `
+Array [
+  Object {
+    "cmd": "yarn install --ignore-engines --ignore-platform --network-timeout 100000 --ignore-scripts",
+    "options": Object {
+      "cwd": "some-dir",
+      "encoding": "utf-8",
+      "env": Object {
+        "CI": "true",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;

--- a/lib/modules/manager/npm/post-update/yarn.spec.ts
+++ b/lib/modules/manager/npm/post-update/yarn.spec.ts
@@ -123,6 +123,24 @@ describe('modules/manager/npm/post-update/yarn', () => {
     expect(fixSnapshots(execSnapshots)).toMatchSnapshot();
   });
 
+  it('uses corepack if packageManager is set', async () => {
+    Fixtures.mock(
+      {
+        'yarn.lock': 'package-lock-contents',
+      },
+      'some-dir'
+    );
+    const execSnapshots = mockExecAll(exec, {
+      stdout: '2.1.0',
+      stderr: '',
+    });
+    const config = { managerData: { packageManager: true } };
+    const res = await yarnHelper.generateLockFile('some-dir', {}, config);
+    expect(res.lockFile).toBe('package-lock-contents');
+    expect(fixSnapshots(execSnapshots)).toMatchSnapshot();
+    // TODO: check docker preCommands
+  });
+
   it.each([
     ['1.22.0', '^1.10.0'],
     ['2.1.0', '>= 2.0.0'],

--- a/lib/modules/manager/npm/post-update/yarn.ts
+++ b/lib/modules/manager/npm/post-update/yarn.ts
@@ -86,12 +86,17 @@ export async function generateLockFile(
     const isYarnModeAvailable =
       minYarnVersion && semver.gte(minYarnVersion, '3.0.0');
 
-    let installYarn = 'npm i -g yarn';
-    if (isYarn1 && minYarnVersion) {
-      installYarn += `@${quote(yarnCompatibility)}`;
-    }
+    const preCommands = [];
+    if (config.managerData?.packageManager) {
+      preCommands.push('npm i -g corepack', 'corepack enable');
+    } else {
+      let installYarn = 'npm i -g yarn';
+      if (isYarn1 && minYarnVersion) {
+        installYarn += `@${quote(yarnCompatibility)}`;
+      }
 
-    const preCommands = [installYarn];
+      preCommands.push(installYarn);
+    }
 
     const extraEnv: ExecOptions['extraEnv'] = {
       NPM_CONFIG_CACHE: env.NPM_CONFIG_CACHE,


### PR DESCRIPTION
This CL updates the NPM post-update processing to use corepack with yarn when yarn is used, and a `packagerManager` field is defined in `package.json`.

## Changes

The NPM manager exposes a boolean field indicating if a `packageManager` is specified in the `package.json`. The yarn post-update handle will use `corepack` when that flag is present. It currently does install corepack via NPM and runs `corepack enable`. This way, the following yarn commands do not need to be changed. If corepack can be preinstalled in the renovate/node image (but not enabled), the installing step could be removed.

## Context

This fixes use-cases when Yarn 2+ is used, but the binary bundle not embedded in the repository. Previously, a Yarn 1 lock file would have been generated.

Closes #14797

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

I added a test for the `packageManager` field detection, and a test for yarn, but that one isn't testing the `preCommands` yet. I didn't find a way to assert them, and only found a TODO comment in the pnpm test suite for a probably similar scenario.

Some tests in https://github.com/jgraichen/renovate-corepack-yarn look good, even when mixing Yarn 1 and 2+ lock files in the same repository.

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
